### PR TITLE
Fix weekly digest to generate a valid param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.swp
 *~
 *.pid
-log
+*log*
 db/*.sqlite3
 tmp
 _site

--- a/app/models/weekly_digest.rb
+++ b/app/models/weekly_digest.rb
@@ -13,7 +13,7 @@ class WeeklyDigest < ActiveRecord::Base
 
   validates_format_of :param, :with => /^2\d{3}-[0-5]\d$/
 
-  before_validation lambda { |r| r.param = [Time.now.year, Date.today.cweek].join("-") if r.param.blank? }
+  before_validation lambda { |r| r.param = Time.now.strftime("%Y-%U") if r.param.blank? }
 
   default_scope :order => "id DESC" # Newest digests first
 

--- a/webrat.log
+++ b/webrat.log
@@ -1,6 +1,0 @@
-# Logfile created on 2014-07-22 15:36:20 -0500 by logger.rb/31641
-REQUESTING PAGE: GET http://www.example.com/signup with {} and HTTP headers {}
-REQUESTING PAGE: GET http://www.example.com/login with {} and HTTP headers {}
-REQUESTING PAGE: GET http://www.example.com/login with {} and HTTP headers {}
-REQUESTING PAGE: GET http://www.example.com/login with {} and HTTP headers {}
-REQUESTING PAGE: GET http://www.example.com/ with {} and HTTP headers {}


### PR DESCRIPTION
https://rollbar.com/tenforward/crantastic/items/1687/

It was generating this as the param:

```
[1] pry(main)> [Time.now.year, Date.today.cweek].join("-")
=> "2017-2"
```

which is missing a leading zero on the week causing the regex (`/^2\d{3}-[0-5]\d$/`) match to fail.
This is what the new code generates

```
[2] pry(main)> Time.now.strftime("%Y-%U")
=> "2017-02"
```